### PR TITLE
Merge $XML_CATALOG_FILES with settings.

### DIFF
--- a/exalt.py
+++ b/exalt.py
@@ -63,7 +63,12 @@ def get_catalog_files():
     # spaces in them.
     catalog_urls = map(lambda file: file_to_uri(file), catalog_files)
 
-    return " ".join(catalog_urls)
+    # Merge with existing path's in environment
+    env_files = os.environ.get("XML_CATALOG_FILES")
+    env_files = env_files.split(' ') if env_files else []
+    env_files += [url for url in catalog_urls if url not in env_files]
+
+    return " ".join(env_files)
 
 
 def reload_settings():


### PR DESCRIPTION
On most Linux boxes the $XML_CATALOG_FILES already contains valid paths.

Therefore exalt's user settings are not mandatory, but it replaces valid environment variables with its own possibly incorrect file paths. This may prevent lxml to find catalog files and makes it crucial to set up the paths in Exalt's settings.

Therefore catalog files from Exalt.sublime-settings should rather be merged with existing entries in $XML_CATALOG_FILES instead of replacing them.

This is what this PR does.