### PR TITLE
Add PreTeXt to syntax list

### DIFF
--- a/view.py
+++ b/view.py
@@ -26,7 +26,7 @@ def get_syntax(view):
 
 
 def is_xml(view):
-    return get_syntax(view) in ["XML", "XHTML", "XSL", "XSLT"]
+    return get_syntax(view) in ["XML", "XHTML", "XSL", "XSLT", "PreTeXt"]
 
 
 def is_html(view):


### PR DESCRIPTION
Please feel free to close if this is an unwelcome request. [PreTeXt](https://mathbook.pugetsound.edu) is an XML vocabulary for the generation of scholarly documents that is actively used by a community of one or two hundred authors. Around 50 books have been written in it (that we know of). In addition I wrote [PreTeXtual]() to duplicate some of the functionality of LaTeXtools. It provides a syntax definition that reflects the RELAX-NG schema of PreTeXt. The snippets that give the package much of its utility rely on the scopes that the package provides.

I would like to include instructions for using Exalt to validate PreTeXt in the official documentation, but without the change in this PR, it is either necessary for users to edit the Exalt source themselves or switch syntaxes in Sublime. It would be nice to have it supported natively if this is a change you're willing to make. Thanks for considering it and of course I understand if not. Thanks for your work on Exalt.